### PR TITLE
Optimised Undo and Redo History

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app.*.map.json
 
 /.firebaserc
 .firebase
+.fvm

--- a/lib/view/drawing_canvas/drawing_canvas.dart
+++ b/lib/view/drawing_canvas/drawing_canvas.dart
@@ -15,7 +15,6 @@ class DrawingCanvas extends HookWidget {
   final ValueNotifier<DrawingMode> drawingMode;
   final AnimationController sideBarController;
   final ValueNotifier<Sketch?> currentSketch;
-  final ValueNotifier<Sketch?> removedSketch;
   final ValueNotifier<List<Sketch>> allSketches;
   final GlobalKey canvasGlobalKey;
   final ValueNotifier<int> polygonSides;
@@ -31,7 +30,6 @@ class DrawingCanvas extends HookWidget {
     required this.drawingMode,
     required this.sideBarController,
     required this.currentSketch,
-    required this.removedSketch,
     required this.allSketches,
     required this.canvasGlobalKey,
     required this.filled,
@@ -68,8 +66,6 @@ class DrawingCanvas extends HookWidget {
   }
 
   void onPointerMove(PointerMoveEvent details, BuildContext context) {
-    // clear removed sketch to disable 'redo' button
-    removedSketch.value = null;
     final box = context.findRenderObject() as RenderBox;
     final offset = box.globalToLocal(details.position);
     final points = List<Offset>.from(currentSketch.value?.points ?? [])

--- a/lib/view/drawing_canvas/widgets/canvas_side_bar.dart
+++ b/lib/view/drawing_canvas/widgets/canvas_side_bar.dart
@@ -22,7 +22,6 @@ class CanvasSideBar extends StatefulHookWidget {
   final ValueNotifier<double> eraserSize;
   final ValueNotifier<DrawingMode> drawingMode;
   final ValueNotifier<Sketch?> currentSketch;
-  final ValueNotifier<Sketch?> removedSketch;
   final ValueNotifier<List<Sketch>> allSketches;
   final GlobalKey canvasGlobalKey;
   final ValueNotifier<bool> filled;
@@ -34,7 +33,6 @@ class CanvasSideBar extends StatefulHookWidget {
     required this.strokeSize,
     required this.eraserSize,
     required this.drawingMode,
-    required this.removedSketch,
     required this.currentSketch,
     required this.allSketches,
     required this.canvasGlobalKey,

--- a/lib/view/drawing_canvas/widgets/canvas_side_bar.dart
+++ b/lib/view/drawing_canvas/widgets/canvas_side_bar.dart
@@ -413,7 +413,7 @@ class _UndoRedoStack {
 
   void _sketchesCountListener() {
     if (sketchesNotifier.value.length > _sketchCount) {
-      //if user draws new sketch,
+      //if a new sketch is drawn,
       //history is invalidated so clear redo stack
       _redoStack.clear();
       _canRedo.value = false;

--- a/lib/view/drawing_page.dart
+++ b/lib/view/drawing_page.dart
@@ -22,7 +22,6 @@ class DrawingPage extends HookWidget {
 
     ValueNotifier<Sketch?> currentSketch = useState(null);
     ValueNotifier<List<Sketch>> allSketches = useState([]);
-    ValueNotifier<Sketch?> removedSketch = useState(null);
 
     final animationController = useAnimationController(
       duration: const Duration(milliseconds: 150),
@@ -44,7 +43,6 @@ class DrawingPage extends HookWidget {
               eraserSize: eraserSize,
               sideBarController: animationController,
               currentSketch: currentSketch,
-              removedSketch: removedSketch,
               allSketches: allSketches,
               canvasGlobalKey: canvasGlobalKey,
               filled: filled,
@@ -65,7 +63,6 @@ class DrawingPage extends HookWidget {
                 strokeSize: strokeSize,
                 eraserSize: eraserSize,
                 currentSketch: currentSketch,
-                removedSketch: removedSketch,
                 allSketches: allSketches,
                 canvasGlobalKey: canvasGlobalKey,
                 filled: filled,


### PR DESCRIPTION
### Adds **_UndoRedoStack** data structure to retain history for undo and redo.

The **_UndoRedoStack** data structure manages a collection of sketches that can be redone and exposes a **ValueNotifier<bool> canRedo** for the Redo button to listen to.
The data structure's redo history is invalidated whenever a new sketch is made.

**_UndoRedoStack** allows for:
- Undo
- Redo
- Clear