### PR TITLE
Adding background image to canvas

### DIFF
--- a/lib/view/drawing_canvas/drawing_canvas.dart
+++ b/lib/view/drawing_canvas/drawing_canvas.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
+import 'dart:ui';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Image;
 import 'package:flutter_drawing_board/main.dart';
 import 'package:flutter_drawing_board/view/drawing_canvas/models/drawing_mode.dart';
 import 'package:flutter_drawing_board/view/drawing_canvas/models/sketch.dart';
@@ -11,6 +12,7 @@ class DrawingCanvas extends HookWidget {
   final double width;
   final ValueNotifier<Color> selectedColor;
   final ValueNotifier<double> strokeSize;
+  final ValueNotifier<Image?> backgroundImage;
   final ValueNotifier<double> eraserSize;
   final ValueNotifier<DrawingMode> drawingMode;
   final AnimationController sideBarController;
@@ -34,6 +36,7 @@ class DrawingCanvas extends HookWidget {
     required this.canvasGlobalKey,
     required this.filled,
     required this.polygonSides,
+    required this.backgroundImage,
   }) : super(key: key);
 
   @override
@@ -107,6 +110,7 @@ class DrawingCanvas extends HookWidget {
               child: CustomPaint(
                 painter: SketchPainter(
                   sketches: sketches,
+                  backgroundImage: backgroundImage.value,
                 ),
               ),
             ),
@@ -143,11 +147,25 @@ class DrawingCanvas extends HookWidget {
 
 class SketchPainter extends CustomPainter {
   final List<Sketch> sketches;
+  final Image? backgroundImage;
 
-  const SketchPainter({Key? key, required this.sketches});
+  const SketchPainter({
+    Key? key,
+    this.backgroundImage,
+    required this.sketches,
+  });
 
   @override
   void paint(Canvas canvas, Size size) {
+    if (backgroundImage != null) {
+      canvas.drawImageRect(
+        backgroundImage!,
+        Rect.fromLTWH(0, 0, backgroundImage!.width.toDouble(),
+            backgroundImage!.height.toDouble()),
+        Rect.fromLTWH(0, 0, size.width, size.height),
+        Paint(),
+      );
+    }
     for (Sketch sketch in sketches) {
       final points = sketch.points;
       if (points.isEmpty) return;

--- a/lib/view/drawing_canvas/widgets/canvas_side_bar.dart
+++ b/lib/view/drawing_canvas/widgets/canvas_side_bar.dart
@@ -1,5 +1,3 @@
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' show AnchorElement;
 import 'dart:ui' as ui;
 
 import 'package:file_saver/file_saver.dart';
@@ -292,7 +290,7 @@ class CanvasSideBar extends HookWidget {
 
   void saveFile(Uint8List bytes, String extension) async {
     if (kIsWeb) {
-      AnchorElement()
+      html.AnchorElement()
         ..href = '${Uri.dataFromBytes(bytes, mimeType: 'image/$extension')}'
         ..download =
             'FlutterLetsDraw-${DateTime.now().toIso8601String()}.$extension'

--- a/lib/view/drawing_canvas/widgets/canvas_side_bar.dart
+++ b/lib/view/drawing_canvas/widgets/canvas_side_bar.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
+import 'dart:developer';
 import 'dart:io';
 import 'dart:ui' as ui;
-import 'dart:ui';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:file_saver/file_saver.dart';
@@ -29,7 +29,7 @@ class CanvasSideBar extends HookWidget {
   final GlobalKey canvasGlobalKey;
   final ValueNotifier<bool> filled;
   final ValueNotifier<int> polygonSides;
-  final ValueNotifier<Image?> backgroundImage;
+  final ValueNotifier<ui.Image?> backgroundImage;
 
   const CanvasSideBar({
     Key? key,
@@ -242,22 +242,19 @@ class CanvasSideBar extends HookWidget {
                   child: const Text('Clear'),
                   onPressed: () => undoRedoStack.value.clear(),
                 ),
-                ValueListenableBuilder<Image?>(
-                  valueListenable: backgroundImage,
-                  builder: (_, image, __) {
-                    return TextButton(
-                      onPressed: () async {
-                        if (image != null) {
-                          backgroundImage.value = null;
-                        } else {
-                          backgroundImage.value = await _getImage;
-                        }
-                      },
-                      child: Text(
-                        image == null ? 'Add Background' : 'Remove Background',
-                      ),
-                    );
+                TextButton(
+                  onPressed: () async {
+                    if (backgroundImage.value != null) {
+                      backgroundImage.value = null;
+                    } else {
+                      backgroundImage.value = await _getImage;
+                    }
                   },
+                  child: Text(
+                    backgroundImage.value == null
+                        ? 'Add Background'
+                        : 'Remove Background',
+                  ),
                 ),
                 TextButton(
                   child: const Text('Fork on Github'),
@@ -330,8 +327,8 @@ class CanvasSideBar extends HookWidget {
     }
   }
 
-  Future<Image> get _getImage async {
-    final completer = Completer<Image>();
+  Future<ui.Image> get _getImage async {
+    final completer = Completer<ui.Image>();
     if (!kIsWeb && !Platform.isAndroid && !Platform.isIOS) {
       final file = await FilePicker.platform.pickFiles(
         type: FileType.image,
@@ -352,6 +349,7 @@ class CanvasSideBar extends HookWidget {
       final image = await ImagePicker().pickImage(source: ImageSource.gallery);
       if (image != null) {
         final bytes = await image.readAsBytes();
+        log('bytes: ${await decodeImageFromList(bytes)}');
         completer.complete(
           decodeImageFromList(bytes),
         );

--- a/lib/view/drawing_page.dart
+++ b/lib/view/drawing_page.dart
@@ -1,4 +1,6 @@
-import 'package:flutter/material.dart';
+import 'dart:ui';
+
+import 'package:flutter/material.dart' hide Image;
 import 'package:flutter_drawing_board/main.dart';
 import 'package:flutter_drawing_board/view/drawing_canvas/drawing_canvas.dart';
 import 'package:flutter_drawing_board/view/drawing_canvas/models/drawing_mode.dart';
@@ -17,6 +19,7 @@ class DrawingPage extends HookWidget {
     final drawingMode = useState(DrawingMode.pencil);
     final filled = useState<bool>(false);
     final polygonSides = useState<int>(3);
+    final backgroundImage = useState<Image?>(null);
 
     final canvasGlobalKey = GlobalKey();
 
@@ -47,6 +50,7 @@ class DrawingPage extends HookWidget {
               canvasGlobalKey: canvasGlobalKey,
               filled: filled,
               polygonSides: polygonSides,
+              backgroundImage: backgroundImage,
             ),
           ),
           Positioned(
@@ -67,6 +71,7 @@ class DrawingPage extends HookWidget {
                 canvasGlobalKey: canvasGlobalKey,
                 filled: filled,
                 polygonSides: polygonSides,
+                backgroundImage: backgroundImage,
               ),
             ),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,6 +43,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.16.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.3+2"
   crypto:
     dependency: transitive
     description:
@@ -85,6 +92,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.4"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.2.2"
   file_saver:
     dependency: "direct main"
     description:
@@ -118,6 +132,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.7"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -149,6 +170,55 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.1"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.5"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.8.6"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.8.5+3"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.10"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.8.6+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.6.2"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: "none" # Remove this line if you wish to publish to pub.dev
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.1 <3.0.0'
+  sdk: ">=2.18.1 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -58,7 +58,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
   font_awesome_flutter: ^10.2.1
   url_launcher: ^6.1.6
   universal_html: ^2.0.8
+  image_picker: ^0.8.6
+  file_picker: ^5.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The background image feature gives users the option to paint on images instead of just plain canvas.

Alongside the PR comes a fix for mac os users experiencing a dart:html not found error.

Packages added:
* [Image Picker](https://pub.dev/packages/image_picker)
* [File Picker](https://pub.dev/packages/file_picker)