### PR TITLE
Update main.dart to resolve overlap conflict between elements in ui

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_drawing_board/src/src.dart';
 
 void main() {
-  runApp(const LetsDrawApp());
+  runApp(const SafeArea(child: DrawingPage()),);
 }
 
 const Color kCanvasColor = Color(0xfff2f3f7);


### PR DESCRIPTION
The app drawer icon is conflicting with notification bar at the top left corner of screen in mobile devices i.e., it cannot be pressed as being overlapped. SafeArea widget solves that issue.